### PR TITLE
Fix marker type on list requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .vscode/
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "e-trade-api",
-			"version": "0.2.3",
+			"version": "0.2.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"axios": "^0.21.1",

--- a/src/e-trade-api.ts
+++ b/src/e-trade-api.ts
@@ -779,18 +779,48 @@ export interface GetAccountBalancesResponse {
 
 export interface ListTransactionsRequest {
 	accountIdKey: string;
+	/**
+	 * The earliest date to include in the date range, formatted as MMDDYYYY. History is available for two years.
+	 */
 	startDate?: string;
+	/**
+	 * The latest date to include in the date range, formatted as MMDDYYYY.
+	 */
 	endDate?: string;
 	sortOrder?: sortOrder;
-	marker?: number;
+	/**
+	 * Used for pagination, this specifies this starting point of the set of items to return.
+	 * To page through all the items, repeat the request with the marker from each previous response until you receive a response with a count less than the one you specified, indicating that there are no more items.
+	 */
+	marker?: string;
+	/**
+	 * Number of transactions to return in the response. If specified, must be between 1 and 50 inclusive. Defaults to 50.
+	 */
 	count?: number;
 }
 
 export interface ListTransactionsResponse {
 	pageMarkers: string;
+	/**
+	 * Whether or not there are more transactions on a further page.
+	 */
 	moreTransactions: boolean;
+	/**
+	 * Number of transactions in this response. Equivalent to Transaction.length.
+	 */
 	transactionCount: number;
+	/**
+	 * Total number of transactions across all pages.
+	 */
 	totalCount: number;
+	/**
+	 * URL to retrieve the next set of transactions in the pagination series.
+	 */
+	next?: string;
+	/**
+	 * Used for pagination, this marker should be supplied to the next ListTransactionsRequest to fetch the next page.
+	 */
+	marker?: string;
 	Transaction: Transaction[]
 }
 
@@ -876,7 +906,7 @@ export interface GetOptionExpireDatesRequest {
 
 export interface ListOrdersRequest {
 	accountIdKey: string;
-	marker?: number;
+	marker?: string;
 	count?: number;
 	status?: orderStatus;
 	fromDate?: string;


### PR DESCRIPTION
## Background
- we started paginating our list transaction calls, and noticed `marker` is a string as shown in the final example here: https://apisb.etrade.com/docs/api/account/api-transaction-v1.html#copy-link-9
- also added some comments based on those docs to hopefully make it easier to understand how to paginate

## Other notes
- ignored IntelliJ files so that IDE can be used instead of vscode
- `package-lock.json` changed automatically for me when running `npm i` and it appears to be a valid change

## Questions
- how does version bumping work on this project? should i bump as part of this PR?